### PR TITLE
Only initialize neverbleed privsep if active

### DIFF
--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -1378,6 +1378,9 @@ static void set_privsep_socket(void)
     struct sockaddr_un sun;
     int sock, ret;
 
+    if (!h2o_priv_active()) {
+        return;
+    }
     /*
      * Activate the neverbleed sandbox policy. We already have our socket
      * descriptor that h2o will use for cryptographic operations. The only

--- a/include/h2o/privsep.h
+++ b/include/h2o/privsep.h
@@ -157,6 +157,7 @@ enum {
 /*
  * Wrapper functions for privsep/regular mode.
  */
+int              h2o_priv_active(void);
 int              h2o_priv_init(h2o_globalconf_t *);
 void             h2o_priv_bind_sandbox(int);
 int              h2o_priv_get_neverbleed_sock(struct sockaddr_un *);

--- a/lib/common/priv_wrapper.c
+++ b/lib/common/priv_wrapper.c
@@ -27,6 +27,12 @@
 
 static int privsep_state = PRIVSEP_STATE_OFF;
 
+int h2o_priv_active(void)
+{
+
+    return (privsep_state == PRIVSEP_STATE_ACTIVE);
+}
+
 FILE *h2o_priv_fopen(const char * restrict path, const char * restrict mode)
 {
 


### PR DESCRIPTION
- Introduce accessor which checks privsep state
- Only initialize neverbleed privsep socket if privsep state is active